### PR TITLE
Table row template can access NgFor local variables

### DIFF
--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -20,22 +20,26 @@ import { TableComponentModule } from '../shared/ui/table.component';
     <!-- Highly configured template with conditional elements -->
     <app-table [data]="inventory">
       <ng-template #headers>
+        <th></th>
         <th>Item</th>
         <th>Price</th>
         <th></th>
         <th></th>
       </ng-template>
-      <ng-template #rows let-row>
-        <td>{{ row.name }}</td>
-        <td>{{ row.price | currency: row.currency }}</td>
-        <td>
-          <button *ngIf="row.inStock > 0" (click)="purchaseItem(row.plu)">
-            Buy now
-          </button>
-        </td>
-        <td>
-          <button>Delete</button>
-        </td>
+      <ng-template #rows let-row let-i="index">
+        <tr>
+          <td>{{ i + 1 }}</td>
+          <td>{{ row.name }}</td>
+          <td>{{ row.price | currency: row.currency }}</td>
+          <td>
+            <button *ngIf="row.inStock > 0" (click)="purchaseItem(row.plu)">
+              Buy now
+            </button>
+          </td>
+          <td>
+            <button>Delete</button>
+          </td>
+        </tr>
       </ng-template>
     </app-table>
   `,

--- a/src/app/shared/ui/table.component.ts
+++ b/src/app/shared/ui/table.component.ts
@@ -22,14 +22,11 @@ import {
         </tr>
       </thead>
       <tbody>
-        <tr *ngFor="let row of data">
-          <ng-container
-            *ngTemplateOutlet="
-              rows || defaultRowTemplate;
-              context: { $implicit: row }
-            "
-          ></ng-container>
-        </tr>
+        <ng-template
+          ngFor
+          [ngForOf]="data"
+          [ngForTemplate]="rows || defaultRowTemplate"
+        ></ng-template>
       </tbody>
     </table>
 
@@ -39,7 +36,9 @@ import {
     </ng-template>
 
     <ng-template #defaultRowTemplate let-row>
-      <td *ngFor="let row of row | keyvalue">{{ row.value }}</td>
+      <tr>
+        <td *ngFor="let row of row | keyvalue">{{ row.value }}</td>
+      </tr>
     </ng-template>
   `,
   styles: [


### PR DESCRIPTION
Changed the way that `TableComponent` renders the given row templates, such that rows can have access to all local variables typically available when using `*ngFor`. 

The full list of local variables, as well as more information on the `ngFor` directive can be found [in the Angular documentation](https://angular.io/api/common/NgForOf). 

To illustrate the use of a local variable in a row template, added row numbers to the table example in `HomeComponent`. The row number is based on the `index` variable.  

One caveat to this way of rendering the rows is that it requires the `<tr>` element to be part of the template, where this was not the case before. Updated the default template as well as the example table in `HomeComponent` with this new constraint in mind.




